### PR TITLE
audio: add set_parameters for listen hal

### DIFF
--- a/include/hardware/audio.h
+++ b/include/hardware/audio.h
@@ -28,6 +28,9 @@
 #include <hardware/hardware.h>
 #include <system/audio.h>
 #include <hardware/audio_effect.h>
+#ifdef AUDIO_LISTEN_ENABLED
+#include <listen_types.h>
+#endif
 
 __BEGIN_DECLS
 
@@ -652,6 +655,27 @@ struct audio_hw_device {
     int (*set_audio_port_config)(struct audio_hw_device *dev,
                          const struct audio_port_config *config);
 
+#ifdef AUDIO_LISTEN_ENABLED
+    /** This method opens the listen session and returns a handle */
+    int (*open_listen_session)(struct audio_hw_device *dev,
+                               struct listen_open_params*,
+                               struct listen_session** handle);
+
+    /** This method closes the listen session  */
+    int (*close_listen_session)(struct audio_hw_device *dev,
+                                struct listen_session* handle);
+
+    /** This method sets the mad observer callback  */
+    int (*set_mad_observer)(struct audio_hw_device *dev,
+                            listen_callback_t cb_func);
+
+    /*  This method is used for setting listen hal specfic parameters.
+     *  If multiple paramets are set in one call and setting any one of them
+     *  fails it will return failure.
+     */
+    int (*listen_set_parameters)(struct audio_hw_device *dev,
+                                 const char *kv_pairs);
+#endif
 };
 typedef struct audio_hw_device audio_hw_device_t;
 


### PR DESCRIPTION
Add listen hal specific set parameters function so that Listen
service can call Listen hal directly, by passing audio hal. This
is needed since set_parameters call in audio hal does not guarantee the
correct return value is returned for any parameters set.

Change-Id: I647b9e7f841c8157e4eb597655166ea863a00925
